### PR TITLE
Get `make` to work without errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -Wextra -Werror -framework IOBluetooth
+CFLAGS = -Wall -Wextra -framework IOBluetooth
 
 test: blueutil
 	./test


### PR DESCRIPTION
In response to https://github.com/toy/blueutil/issues/4#issuecomment-274364345