### PR TITLE
Also search paired devices to get device by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Document macOS >= 12 silently ignoring favourites and recent access date [#63](https://github.com/toy/blueutil/issues/63) [#84](https://github.com/toy/blueutil/issues/84) [#89](https://github.com/toy/blueutil/issues/89) [@toy](https://github.com/toy)
+* In addition to recent devices, paired devices will also be searched when connect, disconnect, get information about, and check connected state of device by name [#62](https://github.com/toy/blueutil/issues/62) [#88](https://github.com/toy/blueutil/pull/88) [@azuwis](https://github.com/azuwis)
 
 ## v2.9.1 (2023-01-14)
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Without options outputs current state
     -v, --version             show version
 
 STATE can be one of: 1, on, 0, off, toggle
-ID can be either address in form xxxxxxxxxxxx, xx-xx-xx-xx-xx-xx or xx:xx:xx:xx:xx:xx, or name of device to search in used devices
+ID can be either address in form xxxxxxxxxxxx, xx-xx-xx-xx-xx-xx or xx:xx:xx:xx:xx:xx, or name of device to search in paired or recent devices
 OP can be one of: >, >=, <, <=, =, !=; or equivalents: gt, ge, lt, le, eq, ne
 PERIOD is in seconds, defaults to 1
 TIMEOUT is in seconds, default value 0 doesn't add timeout


### PR DESCRIPTION
IOBluetoothDevice.recentDevices return empty list in macOS Monterey and
later, also search paired devices to make

  --info "BY NAME"
  --connect "BY NAME"
  --disconnect "BY NAME"
  ...

work again.

Fix #62